### PR TITLE
Add a select for the start and end canvas for sequence and range downloads

### DIFF
--- a/iiif2pdf.css
+++ b/iiif2pdf.css
@@ -8,3 +8,10 @@
 progress.iiif2pdf {
   width:80%;
 }
+
+#iiif2pdf_hint {
+  color: #aa4433;
+  display: inline-block;
+  max-width: 600px;
+  line-height: 1.5em;
+}

--- a/iiif2pdf.js
+++ b/iiif2pdf.js
@@ -217,7 +217,7 @@ function iiif2pdf(config) {
     select.setAttribute("id", elementId)
     select.classList.add("iiif2pdf")
     for (var c in this.m.canvases) {
-      var label = this.m.defaultSequenceCanvasLabels[this.m.canvases[c]]+" ("+(this.m.defaultSequenceCanvases.indexOf(this.m.canvases[c])+1)+")";
+      var label = this.m.sequenceCanvasLabels[this.m.canvases[c]]+" ("+(this.m.sequenceCanvases.indexOf(this.m.canvases[c])+1)+")";
       var option = document.createElement("option")
       option.setAttribute("value", this.m.canvases[c])
       if (canvasId == this.m.canvases[c]) {
@@ -231,7 +231,7 @@ function iiif2pdf(config) {
   
   controllerGUI.prototype.updateSizeHint = function() {
     if (!setup["showWarning"]) return;
-    if (this.m.canvases.indexOf(this.lastCanvas) - this.m.canvases.indexOf(this.firstCanvas) > setup["warningNumberOfPages"]) {
+    if (this.m.canvases.indexOf(this.lastCanvas) - this.m.canvases.indexOf(this.firstCanvas) + 1 > setup["warningNumberOfPages"]) {
       this.hint.innerHTML = setup.i18n.numberOfPagesWarning
     } else {
       this.hint.innerHTML = ''
@@ -368,22 +368,25 @@ function iiif2pdf(config) {
   }
 
   iiifManifest.prototype.parseManifest = function() {
+    this.sequenceCanvasLabels = {};
+    this.sequenceCanvases = [];
+
     var subset = this.getSubset(setup["uri"])
     if(subset['@type']=="sc:Range") {
       this.iiifobj = new iiifRange(subset)
+      for (var cv in this.data.sequences[0].canvases) {
+        this.sequenceCanvasLabels[this.data.sequences[0].canvases[cv]['@id']] = this.data.sequences[0].canvases[cv]['label'];
+        this.sequenceCanvases.push(this.data.sequences[0].canvases[cv]['@id']);
+      }
     } else if(subset['@type']=="sc:Sequence") {
       this.iiifobj = new iiifSequence(subset)
+      for(var cv in this.iiifobj.data['canvases']) {
+        this.sequenceCanvasLabels[this.iiifobj.data['canvases'][cv]['@id']] = this.iiifobj.data['canvases'][cv]['label'];
+        this.sequenceCanvases.push(this.iiifobj.data['canvases'][cv]['@id']);
+      }
     } else if(subset['@type']=="sc:Canvas") {
       this.iiifobj = new iiifCanvas(subset)
     }
-    
-    this.defaultSequenceCanvasLabels = {};
-    this.defaultSequenceCanvases = [];
-    for (var cv in this.data.sequences[0].canvases) {
-      this.defaultSequenceCanvasLabels[this.data.sequences[0].canvases[cv]['@id']] = this.data.sequences[0].canvases[cv]['label'];
-      this.defaultSequenceCanvases.push(this.data.sequences[0].canvases[cv]['@id']);
-    }
-
     this.canvases = this.iiifobj.getCanvases()
   }
   

--- a/iiif2pdf.js
+++ b/iiif2pdf.js
@@ -22,7 +22,7 @@ function iiif2pdf(config) {
       ready: 'Fertig.',
       firstCanvas: 'Seiten von',
       lastCanvas: 'bis',
-      numberOfPagesWarning: 'You have selected a large number of pages. The PDF generation might take some time and severely affect your browser\'s performance, depending on the size.',
+      numberOfPagesWarning: 'Sie haben eine große Anzahl von Seiten ausgewählt. Das Erzeugen des PDF kann je nach Größe eine längere Zeit in Anspruch nehmen und den Browser erheblich auslasten.',
     },
     en: {
       selectResolution: 'Select Resolution',
@@ -36,7 +36,7 @@ function iiif2pdf(config) {
       ready: 'Ready.',
       firstCanvas: 'Pages from',
       lastCanvas: 'to',
-      numberOfPagesWarning: 'Sie haben eine große Anzahl von Seiten ausgewählt. Das Erzeugen des PDF kann je nach Größe eine längere Zeit in Anspruch nehmen und den Browser erheblich auslasten.',
+      numberOfPagesWarning: 'You have selected a large number of pages. The PDF generation might take some time and severely affect your browser\'s performance, depending on the size.',
     }
   }
 
@@ -125,12 +125,13 @@ function iiif2pdf(config) {
 
     divid.appendChild(document.createElement("br"))
 
-    this.hint = document.createElement("span")
-    this.hint.setAttribute("id", "iiif2pdf_hint")
-    this.hint.classList.add("iiif2pdf")
-    divid.appendChild(this.hint)
-
-    divid.appendChild(document.createElement("br"))
+    if (setup["showWarning"]) {
+      this.hint = document.createElement("span")
+      this.hint.setAttribute("id", "iiif2pdf_hint")
+      this.hint.classList.add("iiif2pdf")
+      divid.appendChild(this.hint)
+      divid.appendChild(document.createElement("br"))
+    }
     
     this.btnc = document.createElement("button")
     var create_txt = document.createTextNode(setup.i18n.createPdf)
@@ -231,10 +232,8 @@ function iiif2pdf(config) {
   controllerGUI.prototype.updateSizeHint = function() {
     if (!setup["showWarning"]) return;
     if (this.m.canvases.indexOf(this.lastCanvas) - this.m.canvases.indexOf(this.firstCanvas) > setup["warningNumberOfPages"]) {
-      console.log('set')
       this.hint.innerHTML = setup.i18n.numberOfPagesWarning
     } else {
-      console.log('clear')
       this.hint.innerHTML = ''
     }
   }
@@ -246,7 +245,7 @@ function iiif2pdf(config) {
   controllerGUI.prototype.renderPdf = function() {
     this.btnc.setAttribute("disabled","true")
     this.selr.setAttribute("disabled","true")
-    if (setup["selectFromTo"]) {
+    if (setup["selectFromTo"] && this.m.canvases.length>1) {
       this.selectFirst.setAttribute("disabled","true")
       this.selectLast.setAttribute("disabled","true")
       var actualCanvases = []


### PR DESCRIPTION
- default behaviour does not change
- if option "selectFromTo" is set to true, the start and end canvas for downloads of ranges and sequences can be selected
- if option "showWarning" is set to true, a warning message will appear if the number of selected canvases is over 100 (default value; configurable)