### PR TITLE
Use setup instead of config for selected resolution

### DIFF
--- a/iiif2pdf.js
+++ b/iiif2pdf.js
@@ -102,7 +102,7 @@ function iiif2pdf(config) {
         var option = document.createElement("option")
         option.value = setup.resolutions[i]
         option.text = setup.resolutions[i]
-        if(setup.resolutions[i]==config["resolution"]) {
+        if(setup.resolutions[i]==setup["resolution"]) {
           option.setAttribute("selected",true)
         }
         this.selr.appendChild(option)


### PR DESCRIPTION
Otherwise `setup['resolution']` will be set but the value will not be reflected by the selected value.

The consequence was that "Max" seemed to have been selected in the UI but "1024" was the actual value in `setup` until the select was changed for the first time. In effect, PDFs with the wrong resolution have been created.